### PR TITLE
chore: fix whitespace bug

### DIFF
--- a/src/functions/run.js
+++ b/src/functions/run.js
@@ -26,6 +26,7 @@ module.exports = async function run(data) {
         for (const component of data.components) {
             let q = await askQuestion(component.name)
             if (component.type === PromptoComponentTypes.Array) {
+                q = q.trim();
                 if (!component.split) component.split = PromptoComponentTypes.ArraySplitTypes.Comma
 
                 q = q.split(component.split)


### PR DESCRIPTION
fixed bug where when you add a whitespace to the end of a split type space question it will create an empty string element in the JSON. Fixed by simply trimming the answer.